### PR TITLE
chore: eslint 룰 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,11 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "react/jsx-props-no-spreading": "off",
-    "consistent-return": "off"
+    "consistent-return": "off",
+    "@typescript-eslint/no-misused-promises": [2, {
+      "checksVoidReturn": {
+        "attributes": false
+      }
+    }]
   }
 }


### PR DESCRIPTION
### ⛏️ 작업 내역
- [x] @typescript-eslint/no-misused-promise 룰 조정

### 세부사항
react-hook-form에서 handleSubmit 함수를 넣으면 해당 린트에러가 무조건 뜬다.
react-hook-form 측에서도 논의되고 있지만 제대로 진전은 안되는 것 같고 [관련 내용](https://github.com/orgs/react-hook-form/discussions/8020), 이 룰 자체도 좀 빡빡한 측면이 있어서 다음 글을 참고해 룰을 변경했다. [eslint rule 수정해서 하는 방안](https://github.com/orgs/react-hook-form/discussions/8622#discussioncomment-4060570)

린트는 개발에 도움되라고 설정하는거라 이거 맞추려고 동작 보장이 어느정도 되는 라이브러리의 린트 에러를 해결하기 위해 이것저것 하는 것은 좀 부담이라 여겨져서 그냥 룰을 수정하고자 한다.