### PR TITLE
feature: Button, Input 컴포넌트 

### DIFF
--- a/features/common/components/Button.tsx
+++ b/features/common/components/Button.tsx
@@ -1,0 +1,29 @@
+import { type ButtonHTMLAttributes } from 'react'
+
+import { classNames } from '../utils/classNames'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string
+  selectedStyle?: string
+  defaultStyle?: string
+}
+
+const Button: React.FC<ButtonProps> = ({
+  className = '',
+  defaultStyle = 'bg-ivory text-dark-brown',
+  selectedStyle = 'bg-dark-brown text-ivory',
+  ...props
+}) => {
+  const buttonClassName = classNames(
+    'w-full',
+    'border',
+    'border-beige',
+    'font-semibold',
+    defaultStyle,
+    className
+  )
+
+  return <button className={buttonClassName} {...props} />
+}
+
+export default Button

--- a/features/common/components/Button.tsx
+++ b/features/common/components/Button.tsx
@@ -3,27 +3,21 @@ import { type ButtonHTMLAttributes } from 'react'
 import { classNames } from '../utils/classNames'
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  className?: string
-  selectedStyle?: string
-  defaultStyle?: string
+  isSelected?: boolean
 }
 
-const Button: React.FC<ButtonProps> = ({
-  className = '',
-  defaultStyle = 'bg-ivory text-dark-brown',
-  selectedStyle = 'bg-dark-brown text-ivory',
-  ...props
-}) => {
-  const buttonClassName = classNames(
-    'w-full',
-    'border',
-    'border-beige',
-    'font-semibold',
-    defaultStyle,
-    className
+const Button: React.FC<ButtonProps> = ({ className, isSelected, ...props }) => {
+  return (
+    <button
+      className={classNames(
+        'w-full border border-beige font-semibold',
+        isSelected ?? false
+          ? 'bg-dark-brown text-ivory'
+          : 'bg-ivory text-dark-brown'
+      )}
+      {...props}
+    />
   )
-
-  return <button className={buttonClassName} {...props} />
 }
 
 export default Button

--- a/features/common/components/Button.tsx
+++ b/features/common/components/Button.tsx
@@ -10,10 +10,11 @@ const Button: React.FC<ButtonProps> = ({ className, isSelected, ...props }) => {
   return (
     <button
       className={classNames(
-        'w-full border border-beige font-semibold',
+        'border border-beige font-semibold',
         isSelected ?? false
           ? 'bg-dark-brown text-ivory'
-          : 'bg-ivory text-dark-brown'
+          : 'bg-ivory text-dark-brown',
+        className ?? ''
       )}
       {...props}
     />

--- a/features/common/components/Input.tsx
+++ b/features/common/components/Input.tsx
@@ -17,7 +17,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     <>
       <div
         className={classNames(
-          'relative w-full h-fit border border-light-brown rounded-md',
+          'relative w-full h-fit border border-beige',
           'focus-within:outline focus-within:outline-1 focus-within:outline-light-brown',
           showError && 'border-red-500 focus-within:outline-red-500'
         )}
@@ -25,9 +25,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         <input
           ref={ref}
           className={classNames(
-            'w-full h-12 p-3 border-0 rounded-md outline-none text-md',
+            'w-full h-10 p-3 border-none outline-none text-md text-dark-brown',
             'focus:otuline-none',
-            'placeholder:text-light-brown'
+            'placeholder:text-beige'
           )}
           {...props}
         ></input>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -68,8 +68,8 @@ export default function Page() {
           <p
             className={classNames(
               'relative text-center text-dark-brown',
-              'before:absolute before:top-1/2 before:-translate-y-1/2 before:left-0 before:h-0.5 before:w-[30%] before:bg-light-brown',
-              'after:absolute after:top-1/2 after:-translate-y-1/2 after:right-0 after:h-0.5 after:w-[30%] after:bg-light-brown'
+              'before:absolute before:top-1/2 before:-translate-y-1/2 before:left-0 before:h-0.5 before:w-[30%] before:bg-ivory',
+              'after:absolute after:top-1/2 after:-translate-y-1/2 after:right-0 after:h-0.5 after:w-[30%] after:bg-ivory'
             )}
           >
             SNS 로그인
@@ -95,8 +95,8 @@ export default function Page() {
           <p
             className={classNames(
               'relative text-center text-dark-brown',
-              'before:absolute before:top-1/2 before:-translate-y-1/2 before:left-0 before:h-0.5 before:w-[30%] before:bg-light-brown',
-              'after:absolute after:top-1/2 after:-translate-y-1/2 after:right-0 after:h-0.5 after:w-[30%] after:bg-light-brown'
+              'before:absolute before:top-1/2 before:-translate-y-1/2 before:left-0 before:h-0.5 before:w-[30%] before:bg-ivory',
+              'after:absolute after:top-1/2 after:-translate-y-1/2 after:right-0 after:h-0.5 after:w-[30%] after:bg-ivory'
             )}
           >
             처음 오셨나요?

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -2,6 +2,7 @@ import { Noto_Sans } from 'next/font/google'
 import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 
+import Button from '@/features/common/components/Button'
 import Input from '@/features/common/components/Input'
 import { classNames } from '@/features/common/utils/classNames'
 
@@ -51,9 +52,7 @@ export default function Page() {
             placeholder="비밀번호"
           ></Input>
           <div className="py-1">
-            <button className="w-full h-12 rounded-md bg-dark-brown text-ivory">
-              로그인
-            </button>
+            <Button className="h-12">로그인</Button>
           </div>
         </form>
         <section className="flex items-center justify-center py-3 space-x-2 text-dark-brown">
@@ -102,12 +101,7 @@ export default function Page() {
           >
             처음 오셨나요?
           </p>
-          <button
-            className="w-full h-12 rounded-md mt-3 text-dark-brown border border-light-brown
-          "
-          >
-            회원 가입
-          </button>
+          <Button className="h-12 mt-6"> 회원 가입</Button>
         </section>
       </main>
     </div>


### PR DESCRIPTION
### ⛏️ 작업 내역
- [x] 인풋 스타일링 
- [x] 버튼 컴포넌트 구현, 스타일링
- [x] 로그인 페이지에 적용 테스트 

### 세부사항

-  **승연이가 피그마에 올려놓은 버튼 디자인**
<img width="296" alt="image" src="https://github.com/Team-Sttock/FE/assets/82880442/f67b4545-a85e-4660-bb34-ee9b0e2409f6">
<img width="363" alt="image" src="https://github.com/Team-Sttock/FE/assets/82880442/ad3359ef-6f1a-4290-8e5c-187879d5a8b3">


디폴트스타일에서 선택되면 bg, text 색 반전만 해달라고 해서 셀렉트스타일로 스타일링 값만 적어두었어요. 
혹시 몰라서 피그마 픽셀값 보이게 캡쳐했는데 이 사이즈로 로그인 버튼에 적용하면 진짜 구리길래 ㅎ 임의로 h-12 줬습니다
인풋도 사이즈 수정 없을거라고 해서 일단 h-10 넣었는데,,, 상품 추가할 때 사이즈에 맞출지 로그인 사이즈에 맞출지 애매해서 일단 냅뒀어요 (참고로 상품추가 입력필드에 맞추면 칸이 너무 작고,, 로그인에 맞추면 너무 멍청하게 큼)


### 화면 결과

<img width="393" alt="image" src="https://github.com/Team-Sttock/FE/assets/82880442/8dd26046-eaad-4515-9204-3b78b982ae1c">