### PR TITLE
naming-convention 쪽 eslint 룰 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,21 @@
         "attributes": false
       }
     }],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "variable",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE", "snake_case"]
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase", "PascalCase"]
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase", "UPPER_CASE"]
+      }
+    ],
     "@next/next/no-img-element": "off"
   }
 }


### PR DESCRIPTION
### ⛏️ 작업 내역
- [x] eslint 룰 수정

### 하는 이유

서버 리스폰스 받을 때 _ 아래 철자 있는 경우가 있는데 서버에서 API를 잘 만들었다면 굳이 이름 바꿀 필요가 없습니다. 
그래서 어지간하면 그냥 서버에서 내린 이름 그대로 쓰려고하는데 네이밍 컨벤션 룰이 발목을 잡아서 조금 수정했습니다.

타입은 파스칼과 enum 같은거 대비해서 Upper case 허용했고 변수는 어지간한 컨벤션 다 허용했고 함수는 컴포넌트용 파스칼케이스와 그외 카멜 케이스를 허용해두었습니다. 