### PR TITLE
마이페이지 로직 대부분 구현

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -11,3 +11,5 @@ export const postLogin = async (props: PostLoginProps) =>
       'Content-Type': 'application/json',
     },
   })
+
+export const postLogout = async () => await client.post<MutationRes>('/logout')

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -45,13 +45,6 @@ export interface PostFindLoginIdRes {
 export const postFindLoginId = async (props: PostFindLoginIdProps) =>
   await client.post<PostFindLoginIdRes>('/user/loginId', props)
 
-export interface PostPasswordProps {
-  password: string
-}
-
-export const postPassword = async (props: PostPasswordProps) =>
-  await client.post<MutationRes>('/user/password', props)
-
 export interface PostTempPasswordProps {
   login_id: string
   email: string
@@ -72,6 +65,22 @@ export interface PostSignupProps {
 
 export const postSignup = async (props: PostSignupProps) =>
   await client.post<MutationRes>('/user/signup', props, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+export interface PatchUserProps {
+  login_id: string
+  name: string
+  gender_cd: number
+  email: string
+  family_num: number
+  birthday: string
+}
+
+export const patchUser = async (props: PatchUserProps) =>
+  await client.patch<MutationRes>('/user', props, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -85,3 +85,5 @@ export const patchUser = async (props: PatchUserProps) =>
       'Content-Type': 'application/json',
     },
   })
+
+export const deleteUser = async () => await client.delete<MutationRes>('/user')

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -8,7 +8,7 @@ export interface InputProps
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { isError = false, ...props },
+  { isError = false, readOnly, disabled, ...props },
   ref
 ) {
   return (
@@ -24,8 +24,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
           ref={ref}
           className={classNames(
             'w-full h-10 p-3 border-none outline-none text-md text-dark-brown',
-            'placeholder:text-beige text-sm'
+            'placeholder:text-beige text-sm',
+            readOnly === true || disabled === true ? 'bg-ivory' : ''
           )}
+          readOnly={readOnly}
+          disabled={disabled}
           {...props}
         ></input>
       </div>

--- a/components/LoadingOverlay.tsx
+++ b/components/LoadingOverlay.tsx
@@ -1,0 +1,7 @@
+export default function LoadingOverlay() {
+  return (
+    <div className="fixed w-full h-full top-0 left-0 z-50 bg-black bg-opacity-10 flex items-center justify-center">
+      <div className="animate-spin w-10 h-10 border-4 border-neutral-400 border-t-neutral-800 rounded-full"></div>
+    </div>
+  )
+}

--- a/hooks/auth/useLogout.ts
+++ b/hooks/auth/useLogout.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { postLogout } from '@/apis/auth'
+
+export const useLogout = () =>
+  useMutation({
+    mutationFn: async () => await postLogout(),
+  })

--- a/hooks/user/useDeleteUser.ts
+++ b/hooks/user/useDeleteUser.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { deleteUser } from '@/apis/user'
+
+export const useDeleteUser = () =>
+  useMutation({
+    mutationFn: async () => await deleteUser(),
+  })

--- a/hooks/user/usePatchUser.ts
+++ b/hooks/user/usePatchUser.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { patchUser, type PatchUserProps } from '@/apis/user'
+
+export const usePatchUser = () =>
+  useMutation({
+    mutationFn: async (props: PatchUserProps) => await patchUser(props),
+  })

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,7 +20,7 @@ export async function middleware(req: NextRequest) {
     // Refresh Token 로직짜기. 있던 쿠키 그대로 호출함. 리프레시 한걸 그대로 받음.
     if (status === 401) {
       const { status: refreshStatus, headers: refreshHeaders } = await fetch(
-        `${baseUrl}/api/v1/user/me`,
+        `${baseUrl}/api/v1/`,
         {
           headers: { Cookie: headers.get('cookie') ?? '' },
         }

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -87,15 +87,7 @@ export default function Page() {
           </div>
           <div className="bg-ivory border border-beige px-6 py-8 space-y-6">
             <Link
-              href="/user/notice"
-              className="font-bold text-dark-brown flex items-center justify-between"
-            >
-              <span>공지사항</span>
-              <img src="/icons/arrow-move.svg" alt="arrow-move" />
-            </Link>
-            <Link
-              href="/user/"
-              // 구글폼 연결
+              href="https://docs.google.com/forms/d/e/1FAIpQLSdFydOTe_kBSceYLF7gpGnYEdDEb_9Dok632fo8K0o2X53wZg/viewform"
               className="font-bold text-dark-brown flex items-center justify-between"
             >
               <span>고객센터</span>

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -102,7 +102,7 @@ export default function Page() {
               <img src="/icons/arrow-move.svg" alt="arrow-move" />
             </Link>
             <button
-              className="font-bold text-dark-brown flex items-center justify-between"
+              className="w-full font-bold text-dark-brown flex items-center justify-between"
               onClick={onLogout}
             >
               <span>로그아웃</span>

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -1,6 +1,7 @@
 import { Noto_Sans } from 'next/font/google'
 import Link from 'next/link'
 
+import { useLogout } from '@/hooks/auth/useLogout'
 import { useUser } from '@/hooks/user/useUser'
 import { classNames } from '@/utils/classNames'
 
@@ -9,13 +10,18 @@ const NotoSans = Noto_Sans({
   subsets: ['latin'],
 })
 
-const userInfo = {
-  name: '이승연',
-  email: 'been0822@naver.com',
-}
-
 export default function Page() {
-  const { data, isPending } = useUser()
+  const { data } = useUser()
+  const { mutateAsync } = useLogout()
+
+  const onLogout = async () => {
+    try {
+      await mutateAsync()
+      location.href = '/'
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   return (
     <>
@@ -42,10 +48,10 @@ export default function Page() {
           <div className="flex justify-between items-center border border-beige px-6 py-8 ">
             <div className="flex flex-col space-y-2 items-start justify-start ">
               <div className="flex items-center justify-center gap-1  text-dark-brown ">
-                <span className="font-bold text-xl"></span>
+                <span className="font-bold text-xl">{data?.data.name}</span>
                 <span>님의 스똑</span>
               </div>
-              <span className="text-light-brown">{userInfo.email}</span>
+              <span className="text-light-brown">{data?.data.email}</span>
             </div>
 
             <Link
@@ -95,13 +101,13 @@ export default function Page() {
               <span>고객센터</span>
               <img src="/icons/arrow-move.svg" alt="arrow-move" />
             </Link>
-            <Link
-              href="/user/"
+            <button
               className="font-bold text-dark-brown flex items-center justify-between"
+              onClick={onLogout}
             >
               <span>로그아웃</span>
               <img src="/icons/arrow-move.svg" alt="arrow-move" />
-            </Link>
+            </button>
           </div>
         </div>
       </main>

--- a/pages/user/change-password.tsx
+++ b/pages/user/change-password.tsx
@@ -1,5 +1,8 @@
 import { Noto_Sans } from 'next/font/google'
+import Link from 'next/link'
+import { useForm } from 'react-hook-form'
 
+import Button from '@/components/Button'
 import Input from '@/components/Input'
 import InputLabel from '@/components/InputLabel'
 import { classNames } from '@/utils/classNames'
@@ -9,7 +12,30 @@ const NotoSans = Noto_Sans({
   subsets: ['latin'],
 })
 
+interface PasswordChangeForm {
+  nowPassword: string
+  newPassword: string
+  checkNewPassword: string
+}
+
 export default function Page() {
+  const {
+    register,
+    formState: { errors },
+    watch,
+    handleSubmit,
+  } = useForm<PasswordChangeForm>({
+    mode: 'onChange',
+  })
+
+  const { newPassword } = watch()
+
+  const onSubmit = (props: PasswordChangeForm) => {
+    console.log(props)
+  }
+
+  const onError = () => {}
+
   return (
     <>
       <main className="m-auto max-w-5xl w-full px-4 mb-10">
@@ -32,46 +58,74 @@ export default function Page() {
           <hr className="relative w-full border-1 border-beige" />
         </header>
 
-        <div className="w-full max-w-2xl m-auto flex-col justify-center items-center space-y-4">
+        <form
+          onSubmit={handleSubmit(onSubmit, onError)}
+          className="w-full max-w-2xl m-auto flex-col justify-center items-center space-y-4"
+        >
           <InputLabel
             label="현재 비밀번호"
-            errorMessage="현재 비밀번호를 입력해주세요."
+            errorMessage={errors.nowPassword?.message}
+            required
+            row
           >
             <Input
               type="password"
-              name="currentPassword"
               placeholder="현재 비밀번호를 입력하세요."
+              {...register('nowPassword', {
+                required: '현재 비밀번호는 필수 입력입니다.',
+              })}
             />
           </InputLabel>
           <InputLabel
-            label="새 비밀번호"
-            errorMessage="새 비밀번호를 입력해주세요."
+            label="변경할 비밀번호"
+            errorMessage={errors.newPassword?.message}
+            required
+            row
           >
             <Input
               type="password"
-              name="newPassword"
               placeholder="새 비밀번호를 입력하세요."
+              {...register('newPassword', {
+                required: '새 비밀번호는 필수 입력입니다.',
+                pattern: {
+                  value:
+                    /^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z0-9!@#$%^&*]{6,}$/,
+                  message:
+                    '비밀번호는 영어, 숫자, 특수 문자를 포함하여 6자리 이상이어야 합니다.',
+                },
+              })}
             />
           </InputLabel>
           <InputLabel
             label="비밀번호 확인"
-            errorMessage="비밀번호 확인을 입력해주세요."
+            errorMessage={errors.checkNewPassword?.message}
             required
+            row
           >
-            {/* <Input
-              {...register('password_check', {
-                required: '비밀번호 확인은 필수 입력입니다.',
+            <Input
+              {...register('checkNewPassword', {
+                required: '새 비밀번호 확인은 필수 입력입니다.',
                 validate: {
                   value: (passwordCheck) =>
-                    passwordCheck === password ||
+                    passwordCheck === newPassword ||
                     '비밀번호와 일치하지 않습니다.',
                 },
               })}
               type="password"
-              placeholder="***********"
-            ></Input> */}
+              placeholder="새 비밀번호를 다시 입력하세요."
+            ></Input>
           </InputLabel>
-        </div>
+          <div className="pt-4 flex justify-center items-center space-x-4 w-full">
+            <Link href="/mypage">
+              <Button type="button" className="py-2 px-6">
+                마이페이지로
+              </Button>
+            </Link>
+            <Button className="py-2 px-6" isSelected>
+              변경하기
+            </Button>
+          </div>
+        </form>
       </main>
     </>
   )

--- a/pages/user/change-password.tsx
+++ b/pages/user/change-password.tsx
@@ -1,5 +1,5 @@
 import { Noto_Sans } from 'next/font/google'
-import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { useForm } from 'react-hook-form'
 
 import Button from '@/components/Button'
@@ -19,6 +19,8 @@ interface PasswordChangeForm {
 }
 
 export default function Page() {
+  const router = useRouter()
+
   const {
     register,
     formState: { errors },
@@ -116,12 +118,16 @@ export default function Page() {
             ></Input>
           </InputLabel>
           <div className="pt-4 flex justify-center items-center space-x-4 w-full">
-            <Link href="/mypage">
-              <Button type="button" className="py-2 px-6">
-                마이페이지로
-              </Button>
-            </Link>
-            <Button className="py-2 px-6" isSelected>
+            <Button
+              type="button"
+              className="py-2 px-6"
+              onClick={() => {
+                router.back()
+              }}
+            >
+              돌아가기
+            </Button>
+            <Button type="submit" className="py-2 px-6" isSelected>
               변경하기
             </Button>
           </div>

--- a/pages/user/edit-info.tsx
+++ b/pages/user/edit-info.tsx
@@ -1,4 +1,175 @@
+import { parseISO } from 'date-fns'
+import { Noto_Sans } from 'next/font/google'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { type PatchUserProps } from '@/apis/user'
+import Button from '@/components/Button'
+import DatePickerField from '@/components/DatepickerField'
+import Input from '@/components/Input'
+import InputLabel from '@/components/InputLabel'
+import ListBox from '@/components/ListBox'
+import LoadingOverlay from '@/components/LoadingOverlay'
+import { useModal } from '@/components/Modal'
+import { usePatchUser } from '@/hooks/user/usePatchUser'
+import { useUser } from '@/hooks/user/useUser'
+import { classNames } from '@/utils/classNames'
+
+const NotoSans = Noto_Sans({
+  weight: ['500', '400'],
+  subsets: ['latin'],
+})
+
+interface UpdateUserForm extends Omit<PatchUserProps, 'birthday'> {
+  birthday: Date
+}
+
+const genderOptions = [
+  {
+    value: 1,
+    label: '남성',
+  },
+  {
+    value: 2,
+    label: '여성',
+  },
+]
+
 export default function Page() {
-    return <div>edit-info</div>
+  const router = useRouter()
+
+  const { open: successOpen } = useModal({
+    title: '회원 정보 수정 성공',
+    description: '회원 정보 수정이 완료되었습니다.',
+  })
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<UpdateUserForm>({
+    mode: 'onChange',
+  })
+
+  const { data, isSuccess, isPending: isUserPending } = useUser()
+
+  const { mutateAsync, isPending } = usePatchUser()
+
+  useEffect(() => {
+    if (!isSuccess) return
+    reset({
+      ...data.data,
+      birthday: new Date(parseISO(data.data.birthday)),
+    })
+  }, [data, isSuccess, reset])
+
+  const onSubmit = async (data: UpdateUserForm) => {
+    try {
+      await mutateAsync({ ...data, birthday: data.birthday.toISOString() })
+      await successOpen()
+    } catch (err) {
+      console.log(err)
+    }
   }
-  
+
+  return (
+    <>
+      {isUserPending && <LoadingOverlay />}
+      <main className="m-auto max-w-5xl w-full px-4 mb-10">
+        <header className="mt-10 mb-4 w-full py-2">
+          <div
+            className={classNames(
+              'space-y-2 w-full mb-2',
+              'sm:space-x-4 sm:space-y-0 sm:flex sm:justify-start sm:items-center'
+            )}
+          >
+            <h1
+              className={classNames(
+                'md:text-2xl text-xl font-bold text-dark-brown',
+                NotoSans.className
+              )}
+            >
+              회원정보 수정
+            </h1>
+          </div>
+          <hr className="relative w-full border-1 border-beige" />
+        </header>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="w-full max-w-2xl m-auto flex-col justify-center items-center space-y-4"
+        >
+          <InputLabel
+            label="이름"
+            errorMessage={errors.name?.message}
+            required
+            row
+          >
+            <Input
+              {...register('name', {
+                required: '이름은 필수 입력입니다.',
+              })}
+              placeholder="홍길동"
+            ></Input>
+          </InputLabel>
+          <InputLabel label="이메일" required row>
+            <Input
+              {...register('email')}
+              readOnly
+              placeholder="test@example.com"
+            ></Input>
+          </InputLabel>
+          <InputLabel label="생일" row>
+            <DatePickerField
+              control={control}
+              name={'birthday'}
+            ></DatePickerField>
+          </InputLabel>
+          <InputLabel label="성별" row required>
+            <ListBox
+              name="gender_cd"
+              placeholder="성별"
+              control={control}
+              options={genderOptions}
+            />
+          </InputLabel>
+          <InputLabel
+            errorMessage={errors.name?.message}
+            label="가구원 수"
+            row
+            required
+          >
+            <Input
+              {...register('family_num', {
+                required: '가구원 수는 필수 입력입니다.',
+              })}
+              placeholder="4"
+              type="number"
+            ></Input>
+          </InputLabel>
+          <div className="pt-4 flex justify-center items-center space-x-4 w-full">
+            <Button
+              type="button"
+              className="py-2 px-6"
+              onClick={() => {
+                router.back()
+              }}
+            >
+              돌아가기
+            </Button>
+            <Button
+              type="submit"
+              className="py-2 px-6"
+              isSelected
+              isLoading={isPending}
+            >
+              변경하기
+            </Button>
+          </div>
+        </form>
+      </main>
+    </>
+  )
+}

--- a/pages/user/info.tsx
+++ b/pages/user/info.tsx
@@ -1,6 +1,8 @@
+import { format, parseISO } from 'date-fns'
 import { Noto_Sans } from 'next/font/google'
 import Link from 'next/link'
 
+import { useUser } from '@/hooks/user/useUser'
 import { classNames } from '@/utils/classNames'
 
 const NotoSans = Noto_Sans({
@@ -8,31 +10,30 @@ const NotoSans = Noto_Sans({
   subsets: ['latin'],
 })
 
-const userInfo = {
-  name: '이승연',
-  email: 'been0822@naver.com',
-  loginId: 'been0822',
-  birthday: '2000-08-22',
-  genderCd: '2',
-  familyNum: '1',
+const getGenderLabel = (genderCd: number) => {
+  return genderCd === 1 ? '남성' : '여성'
 }
 
-const getGenderLabel = (genderCd) => {
-  return genderCd === '1' ? '남성' : '여성'
-}
-
-const formatBirthday = (birthday) => {
-  return birthday.replace(/-/g, '.')
+const formatBirthday = (birthday: string) => {
+  return format(parseISO(birthday), 'yyyy.MM.dd')
 }
 
 export default function Page() {
+  const { data } = useUser()
+
   const userInfoFields = [
-    { label: '이름', value: userInfo.name },
-    { label: '이메일', value: userInfo.email },
-    { label: '아이디', value: userInfo.loginId },
-    { label: '생년월일', value: userInfo.birthday },
-    { label: '성별', value: userInfo.genderCd },
-    { label: '가구원수', value: userInfo.familyNum },
+    { label: '이름', value: data?.data.name ?? '' },
+    { label: '이메일', value: data?.data.email ?? '' },
+    { label: '아이디', value: data?.data.login_id ?? '' },
+    {
+      label: '생년월일',
+      value: data?.data.birthday ? formatBirthday(data?.data.birthday) : '',
+    },
+    {
+      label: '성별',
+      value: data?.data.gender_cd ? getGenderLabel(data?.data.gender_cd) : '',
+    },
+    { label: '가구원수', value: data?.data.family_num ?? '' },
   ]
 
   return (
@@ -66,11 +67,7 @@ export default function Page() {
                 >
                   <span className="text-light-brown">{field.label}</span>
                   <span className="font-bold text-dark-brown">
-                    {field.label === '성별'
-                      ? getGenderLabel(userInfo.genderCd)
-                      : (field.label === '생년월일' &&
-                          formatBirthday(userInfo.birthday)) ||
-                        field.value}
+                    {field.value}
                   </span>
                 </div>
               ))}

--- a/pages/user/info.tsx
+++ b/pages/user/info.tsx
@@ -58,7 +58,7 @@ export default function Page() {
           <hr className="relative w-full border-1 border-beige" />
         </header>
         <div className="w-full max-w-2xl m-auto flex-col justify-center items-center space-y-4">
-          <div className="w-full max-w-xl m-auto p-8 flex-col justify-center items-center border border-beige bg-ivory space-y-6  ">
+          <div className="w-full max-w-xl m-auto p-5 flex-col justify-center items-center border border-beige bg-ivory space-y-6  ">
             <div className="flex flex-col justify-center items-center gap-4">
               {userInfoFields.map((field, idx) => (
                 <div

--- a/pages/user/join.tsx
+++ b/pages/user/join.tsx
@@ -343,10 +343,10 @@ export default function Page() {
             </div>
             <hr className="my-4 bg-dark-brown"></hr>
             <div className="space-y-2">
-              <InputLabel label="가족 수" required>
+              <InputLabel label="가구원 수" required>
                 <Input
                   {...register('family_num', {
-                    required: '가족 수는 필수 입력입니다.',
+                    required: '가구원 수는 필수 입력입니다.',
                   })}
                   placeholder="4"
                 ></Input>

--- a/pages/user/leave.tsx
+++ b/pages/user/leave.tsx
@@ -1,7 +1,9 @@
 import { Noto_Sans } from 'next/font/google'
-import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/router'
 
 import Button from '@/components/Button'
+import { useModal } from '@/components/Modal'
+import { useDeleteUser } from '@/hooks/user/useDeleteUser'
 import { classNames } from '@/utils/classNames'
 
 const NotoSans = Noto_Sans({
@@ -9,28 +11,33 @@ const NotoSans = Noto_Sans({
   subsets: ['latin'],
 })
 
-const leaveReason = {
-  1: '서비스 이용에 불편함을 겪었습니다.',
-  2: '스똑의 기능을 이용하기 어렵습니다.',
-  3: '스똑의 디자인이 마음에 들지 않습니다.',
-  4: '스똑의 기능이 마음에 들지 않습니다.',
-  5: '스똑의 가격이 마음에 들지 않습니다.',
-  6: '스똑의 기타 이유로 인해 이용을 중단하고 싶습니다.',
-}
-
-interface LeaveReasonFormData {
-  leaveReason: string
-}
+// const leaveReason = {
+//   1: '서비스 이용에 불편함을 겪었습니다.',
+//   2: '스똑의 기능을 이용하기 어렵습니다.',
+//   3: '스똑의 디자인이 마음에 들지 않습니다.',
+//   4: '스똑의 기능이 마음에 들지 않습니다.',
+//   5: '스똑의 가격이 마음에 들지 않습니다.',
+//   6: '스똑의 기타 이유로 인해 이용을 중단하고 싶습니다.',
+// }
 
 export default function Page() {
-  const { control, handleSubmit } = useForm<LeaveReasonFormData>()
+  const router = useRouter()
 
-  const onSubmit: SubmitHandler<LeaveReasonFormData> = (data) => {
-    console.log(data)
-  }
+  const { open } = useModal({
+    title: '탈퇴 완료',
+    description: '안녕하가세요.',
+  })
 
-  const handleLeaveReasonChange = (value: any) => {
-    console.log('value', value)
+  const { mutateAsync, isPending } = useDeleteUser()
+
+  const onClick = async () => {
+    try {
+      await mutateAsync()
+      await open()
+      await router.push('/')
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (
@@ -73,12 +80,25 @@ export default function Page() {
               </p>
             </div>
           </div>
-          <div>
-            <span className="text-lg text-dark-brown">탈퇴 사유</span>
-          </div>
-          <div className="space-x-10">
-            <Button className="px-2 py-1">탈퇴하기</Button>
-            <Button className="px-2 py-1">돌아가기</Button>
+          <div className="pt-4 flex justify-center items-center space-x-4 w-full">
+            <Button
+              type="button"
+              className="py-2 px-6"
+              onClick={() => {
+                router.back()
+              }}
+            >
+              돌아가기
+            </Button>
+            <Button
+              type="button"
+              className="py-2 px-6"
+              isSelected
+              isLoading={isPending}
+              onClick={onClick}
+            >
+              탈퇴하기
+            </Button>
           </div>
         </div>
       </main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,38 +2,48 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type=number] {
+  -moz-appearance: textfield;
+}
 
 @font-face {
-    font-family: 'NEXON LV2 Gothic';
-    src: url('/fonts/NEXON Lv2 Gothic Light.ttf') format('truetype');
-    font-weight: 300;
-    font-style: normal;
-  }
-  
-  @font-face {
-    font-family: 'NEXON LV2 Gothic';
-    src: url('/fonts/NEXON Lv2 Gothic Medium.ttf') format('truetype');
-    font-weight: 500;
-    font-style: normal;
-  }
-  
-  @font-face {
-    font-family: 'NEXON LV2 Gothic';
-    src: url('/fonts/NEXON Lv2 Gothic Bold.ttf') format('truetype');
-    font-weight: bold;
-    font-style: normal;
-  }
-  
-  @font-face {
-    font-family: 'Hahmlet'; 
-    src: url('/fonts/Hahmlet-VariableFont_wght.ttf') format('truetype');
-  }
-  
-  @font-face {
-    font-family: 'Kimjungchul Gothic';
-    src: url('/fonts/KimjungchulGothic-Bold.otf') format('opentype');
-    
-  }
+  font-family: 'NEXON LV2 Gothic';
+  src: url('/fonts/NEXON Lv2 Gothic Light.ttf') format('truetype');
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'NEXON LV2 Gothic';
+  src: url('/fonts/NEXON Lv2 Gothic Medium.ttf') format('truetype');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'NEXON LV2 Gothic';
+  src: url('/fonts/NEXON Lv2 Gothic Bold.ttf') format('truetype');
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Hahmlet'; 
+  src: url('/fonts/Hahmlet-VariableFont_wght.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Kimjungchul Gothic';
+  src: url('/fonts/KimjungchulGothic-Bold.otf') format('opentype');
+}
 
 .react-datepicker__month-container {
   width: 100% !important;


### PR DESCRIPTION
### ⛏️ 작업 내역
- [x] 회원 정보 뷰어, 수정
- [x] 회원 탈퇴 로직 작성
- [x] 비밀 번호 변경 로직 작성 (미완)
- [x] 마이페이지 시작 화면 변경 (구글 폼 연결도 완료)
- [x] LoadingOverlay 컴포넌트 구현, Input 컴포넌트 약간 수정
<img width="1438" alt="스크린샷 2023-12-17 오후 6 25 39" src="https://github.com/Team-Sttock/FE/assets/52780207/8960254b-8a64-493a-82ae-72924ecf7e76">

### 세부사항
- Input 컴포넌트 조금 수정했어요. 
- LoadingOverlay를 만들었습니다.

### 화면 결과
* 개인정보 수정, (뷰어도 당연히 함)
<img width="1438" alt="스크린샷 2023-12-17 오후 6 16 03" src="https://github.com/Team-Sttock/FE/assets/52780207/ab1e8d12-400c-4bad-ab54-beea9bc7cc15">
* 회원 탈퇴 ( 탈퇴 사유 안함, 탈퇴 연동은 되는데 서버 쪽 수정 필요 )
<img width="1438" alt="스크린샷 2023-12-17 오후 6 16 32" src="https://github.com/Team-Sttock/FE/assets/52780207/8fd9c9f6-cf77-4909-b9d3-1a5bfb663597">
* 비밀번호 변경 ( 서버 쪽 API 변경 필요, 아직 연동 안함 )
<img width="1438" alt="스크린샷 2023-12-17 오후 6 17 24" src="https://github.com/Team-Sttock/FE/assets/52780207/ca1a449c-06be-4900-9555-996d01a55f68">

